### PR TITLE
gh_84_make_drug_vehicle_issue

### DIFF
--- a/snt/helpers_add_interventions.py
+++ b/snt/helpers_add_interventions.py
@@ -519,7 +519,7 @@ def add_hfca_vaccsmc(campaign, smc_df, hfca, effective_coverage_resistance_multi
                                   target_group={'agemin': age_min_list[ii],
                                                 'agemax': age_max_list[ii]},
                                   ind_property_restrictions=[{'SMCAccess': access_list[ii]}],
-                                  receiving_drugs_event=False)  ## If False uses vaccSMC with automatic offset of 17 days, if True, uses vaccDrugSMC
+                                  also_deploy_drugs=False)  ## If False uses vaccSMC with automatic offset of 17 days, if True, uses vaccDrugSMC
 
     return len(df)
 
@@ -869,7 +869,7 @@ def add_ds_vaccpmc(campaign, pmc_df, hfca):
                                                    'delay_distribution_mean': df['distribution_mean'],
                                                    'delay_distribution_std': df['distribution_std']},
                           num_iiv_groups=num_iiv_groups,
-                          receiving_drugs_event=False)  ## use vaccine effects only with default offset of -10 days
+                          also_deploy_drugs=False)  ## use vaccine effects only with default offset of -10 days
 
     return len(pmc_df)
 


### PR DESCRIPTION
removed setting drug parameters from inside interventions as it is nolonger possible. Drug parameters will need to be set in config builder separately from campaign builder.

I also changed confusing receiving_drugs_event_name/receiving_drugs_event to receiving_drugs_event_name and "also_deploy_drugs". In some of the functions receiving_drugs_event was the same as receiving_drugs_event_name, but in another, it was a bool that meant that you were also going to distribute drugs. I made that more explicit. 

This will be code-breakign changes. Once this is pulled in, code that's using these scripts will need to be updated due to parameter changes: removal of vehicle/drug dictionary parameters and receiving_drugs_event->also_deploy_drugs